### PR TITLE
Adds melee aiming 

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -42,6 +42,14 @@
 
 /obj/attackby(obj/item/I, mob/living/user, params)
 	return ..() || ((obj_flags & CAN_BE_HIT) && I.attack_obj(src, user))
+	if(user.a_intent == INTENT_HARM && user.m_intent == MOVE_INTENT_WALK)//if you swing carefully without blocking, you click easier
+		for(var/mob/living/L in get_turf(src))
+			if(L.stat)
+				continue
+			if(user == L)
+				continue
+			L.attackby(I, user)
+			return FALSE
 
 /mob/living/attackby(obj/item/I, mob/living/user, params)
 	if(..())

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -334,6 +334,20 @@
 /obj/proc/plunger_act(obj/item/plunger/P, mob/living/user, reinforced)
 	return
 
+/obj/attack_hand(mob/user)
+	if(user.a_intent == INTENT_HARM && user.m_intent == MOVE_INTENT_WALK)//if you swing carefully without blocking, you click easier
+		for(var/mob/living/L in get_turf(src))
+			if(L.stat)
+				continue
+			if(user == L)
+				continue
+			L.attack_hand(user)
+			user.changeNext_move(CLICK_CD_MELEE)
+			return
+	. = ..()
+	if(.)
+		return
+
 //For returning special data when the object is saved
 //For example, or silos will return a list of their materials which will be dumped on top of them
 //Can be customised if you have something that contains something you want saved

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -128,6 +128,15 @@
 	..()
 
 /turf/attack_hand(mob/user)
+if(user.a_intent == INTENT_HARM && user.m_intent == MOVE_INTENT_WALK)//if you swing carefully without blocking, you click easier
+		for(var/mob/living/L in src)
+			if(L.stat)
+				continue
+			if(user == L)
+				continue
+			L.attack_hand(user)
+			user.changeNext_move(CLICK_CD_MELEE)
+			return
 	. = ..()
 	if(.)
 		return

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -221,7 +221,15 @@ if(user.a_intent == INTENT_HARM && user.m_intent == MOVE_INTENT_WALK)//if you sw
 
 	else if(istype(C, /obj/item/twohanded/rcl))
 		handleRCL(C, user)
-
+		
+	if(user.a_intent == INTENT_HARM && user.m_intent == MOVE_INTENT_WALK)//if you swing carefully without blocking, you click easier
+		for(var/mob/living/L in src)
+			if(L.stat)
+				continue
+			if(user == L)
+				continue
+			L.attackby(C, user)
+			return FALSE
 	return FALSE
 
 /turf/CanPass(atom/movable/mover, turf/target)


### PR DESCRIPTION
(From https://github.com/BeeStation/BeeStation-Hornet/pull/2444)
## About The Pull Request
"Adds melee aiming. meant to go with #2430

while on Walk and Harm intent, your melee attacks will hit mobs that are outside of softcrit if they are in the targeted tile, regardless of if you click their sprite or not"

## Why It's Good For The Game
"speedcombat is still cancer, this accompanies my earlier goal of slowing it down a bit"

## Changelog
🆑
add: you can now hit mobs in melee easier if you are on harm intent and walking (you only need to click the tile, not the sprite itself)
/🆑
